### PR TITLE
fix: correct Swagger API link

### DIFF
--- a/src/app/layout/rail/rail.component.html
+++ b/src/app/layout/rail/rail.component.html
@@ -124,7 +124,7 @@
             <p class="text-[var(--primary-color)] leading-relaxed text-sm m-0">
               {{ 'rail.mail.apiDocumented' | translate }}
             </p>
-            <a href="https://api.mapr.mobi/swagger<" target="_blank" 
+            <a href="https://api.mapr.mobi/swagger" target="_blank"
                class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 hover:underline transition-colors font-medium text-sm">
               <mat-icon class="text-sm">open_in_new</mat-icon>
               <span>api.mapr.mobi/swagger</span>


### PR DESCRIPTION
﻿Summary
- Corrects the API documentation link in the rail menu by removing a stray trailing `<` from the Swagger URL.
- Keeps the visible label and surrounding layout unchanged.
- Fixes #465.

Validation
- `curl.exe -L -I --max-time 20 https://api.mapr.mobi/swagger%3C` returned `404 Not Found`.
- `curl.exe --http1.1 -L -I --max-time 25 https://api.mapr.mobi/swagger` redirected to `/swagger/` and returned `200 OK`.
- `npm ci` failed because the current dependency set has an existing peer conflict: `primeng@20.4.0` expects Angular 20 while the project uses Angular 21.1.0.
- `npm ci --legacy-peer-deps` passed.
- `npm run build` passed with existing Angular budget/CommonJS warnings.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `npm test -- --watch=false --browsers=ChromeHeadless` timed out locally after 244 seconds with no test failure output captured.

Notes
- Related issue: #465.
- No compatibility impact expected; this only restores the intended external Swagger link.
- No follow-up work identified.
